### PR TITLE
Add Terraform example and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Insertion Project Sorting
+
+This repository now includes a simple Terraform setup for launching an EC2 instance.
+
+## Terraform
+
+The Terraform configuration is located in the `terraform/` directory. The instance uses the `cloud-config.yaml.tpl` template for user data, which writes a file to `/etc/example.txt` on boot.
+
+### Setup
+
+1. Install [Terraform](https://terraform.io/).
+2. Configure your AWS credentials (e.g., via `aws configure` or environment variables).
+3. Update the variables in `terraform/variables.tf` or provide them via `terraform.tfvars`.
+4. From the `terraform/` directory run:
+   ```bash
+   terraform init
+   terraform apply
+   ```
+
+This will create a single EC2 instance using the specified AMI and region.

--- a/terraform/cloud-config.yaml.tpl
+++ b/terraform/cloud-config.yaml.tpl
@@ -1,0 +1,7 @@
+#cloud-config
+write_files:
+  - path: /etc/example.txt
+    permissions: '0644'
+    owner: root
+    content: |
+      This file was created via cloud-init

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_instance" "example" {
+  ami           = var.ami
+  instance_type = var.instance_type
+
+  user_data = templatefile("${path.module}/cloud-config.yaml.tpl", {})
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,12 @@
+variable "region" {
+  description = "AWS region"
+}
+
+variable "ami" {
+  description = "AMI to use for the instance"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  default     = "t2.micro"
+}


### PR DESCRIPTION
## Summary
- add a minimal Terraform configuration
- include a cloud-init template
- document Terraform usage in README

## Testing
- `terraform fmt -check` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684834fb7adc83258f7c4caeb1d50ca4